### PR TITLE
Block fast snowflakes

### DIFF
--- a/asnow.c
+++ b/asnow.c
@@ -107,16 +107,27 @@ int
 flake_is_blocked(Screen *scr, Snowflake *snow)
 {
 	int row = (int)floorf(snow->row);
+	int speed = (int)ceilf(snow->speed);
 
+	/* Block if we're at the bottom of the screen */
 	if (row >= scr->rows - 1) {
 		snow->row = scr->rows - 1;
 		return 1;
 	}
-	if (get_from_screen(scr, snow->column, row+1) != ' ')
-		return 1;
-	if ((get_from_screen(scr, (snow->column-1) % scr->columns, row+1) | \
-	    get_from_screen(scr, (snow->column+1) % scr->columns, row+1)) != ' ')
-		return rand() % 2;
+
+	for (int i = 1; i <= speed; i++) {
+		/* Block if we have an obstacle directly below us */
+		if (get_from_screen(scr, snow->column, row+i) != ' ') {
+			snow->row += i - 1;
+			return 1;
+		}
+
+		/* If we have an obstacle in neighboring columns, maybe block */
+		if ((get_from_screen(scr, (snow->column-1) % scr->columns, row+i) | \
+		    get_from_screen(scr, (snow->column+1) % scr->columns, row+i)) != ' ')
+			return rand() % 2;
+        }
+
 	return 0;
 }
 


### PR DESCRIPTION
Extend the blocking test to work with fast snowflakes (i.e. those with speed > 1.0). This should fix issue #4 , and maybe fix issue #5 as well.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>